### PR TITLE
Make SnapshotT() a no-op for failed tests (#31)

### DIFF
--- a/cupaloy.go
+++ b/cupaloy.go
@@ -48,11 +48,7 @@ func SnapshotMulti(snapshotID string, i ...interface{}) error {
 // SnapshotT calls Snapshotter.SnapshotT with the default config.
 func SnapshotT(t *testing.T, i ...interface{}) {
 	t.Helper()
-	snapshotName := strings.Replace(t.Name(), "/", "-", -1)
-	err := defaultConfig().snapshot(snapshotName, i...)
-	if err != nil {
-		t.Error(err)
-	}
+	defaultConfig().SnapshotT(t, i...)
 }
 
 func (c *config) Snapshot(i ...interface{}) error {
@@ -66,10 +62,12 @@ func (c *config) SnapshotMulti(snapshotID string, i ...interface{}) error {
 
 func (c *config) SnapshotT(t *testing.T, i ...interface{}) {
 	t.Helper()
-	snapshotName := strings.Replace(t.Name(), "/", "-", -1)
-	err := c.snapshot(snapshotName, i...)
-	if err != nil {
-		t.Error(err)
+	if !t.Failed() {
+		snapshotName := strings.Replace(t.Name(), "/", "-", -1)
+		err := c.snapshot(snapshotName, i...)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Skips a `cupaloy.SnapshotT()` invocation when the test has already failed. This avoids saving test snapshots containing known-bad data on a test's first invocation.