### PR TITLE
Silence gosec lint error

### DIFF
--- a/util.go
+++ b/util.go
@@ -75,6 +75,10 @@ func takeSnapshot(i ...interface{}) string {
 
 func (c *Config) readSnapshot(snapshotName string) (string, error) {
 	snapshotFile := c.snapshotFilePath(snapshotName)
+	
+	/* #nosec */
+	// disable gosec checks for this line
+	// complains because we're reading a file based on a name unkown at compile time
 	buf, err := ioutil.ReadFile(snapshotFile)
 
 	if os.IsNotExist(err) {


### PR DESCRIPTION
`gosec` was throwing a lint error because of a file read based on user provided name (i.e. a fairly critical feature of `cupaloy`)