### PR TITLE
Global config prototype

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,22 +37,42 @@ func SnapshotSubdirectory(name string) Configurator {
 	}
 }
 
+func FailOnUpdate(failOnUpdate bool) Configurator {
+	return func(c *Config) {
+		c.failOnUpdate = failOnUpdate
+	}
+}
+
+func CreateNewAutomatically(createNewAutomatically bool) Configurator {
+	return func(c *Config) {
+		c.createNewAutomatically = createNewAutomatically
+	}
+}
+
 // Config provides the same snapshotting functions with additional configuration capabilities.
 type Config struct {
 	shouldUpdate func() bool
 	subDirName   string
+	failOnUpdate bool
+	createNewAutomatically bool
 }
 
-func defaultConfig() *Config {
+func NewDefaultConfig() *Config {
 	return (&Config{}).WithOptions(
 		SnapshotSubdirectory(".snapshots"),
 		EnvVariableName("UPDATE_SNAPSHOTS"),
+		FailOnUpdate(true),
+		CreateNewAutomatically(true),
 	)
 }
+
+var Global = NewDefaultConfig()
 
 func (c *Config) clone() *Config {
 	return &Config{
 		shouldUpdate: c.shouldUpdate,
 		subDirName:   c.subDirName,
+		failOnUpdate: c.failOnUpdate,
+		createNewAutomatically: c.createNewAutomatically,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -3,11 +3,11 @@ package cupaloy
 // Configurator is a functional option that can be passed to cupaloy.New() to change snapshotting behaviour.
 type Configurator func(*Config)
 
-// EnvVariableName can be used to customize the environment variable that determines whether snapshots should be updated
-// e.g.
+// EnvVariableName can be used to customize the environment variable that determines whether snapshots
+// should be updated e.g.
 //  cupaloy.New(EnvVariableName("UPDATE"))
-// Will create an instance where snapshots will be updated if the UPDATE environment variable is set,
-// instead of the default of UPDATE_SNAPSHOTS.
+// Will create an instance where snapshots will be updated if the UPDATE environment variable is set.
+// Default: UPDATE_SNAPSHOTS
 func EnvVariableName(name string) Configurator {
 	return func(c *Config) {
 		c.shouldUpdate = func() bool {
@@ -21,6 +21,7 @@ func EnvVariableName(name string) Configurator {
 //   var update = flag.Bool("update", false, "update snapshots")
 //   cupaloy.New(ShouldUpdate(func () bool { return *update })
 // Will create an instance where snapshots are updated if the --update flag is passed to go test.
+// Default: checks for the presence of the UPDATE_SNAPSHOTS environment variable
 func ShouldUpdate(f func() bool) Configurator {
 	return func(c *Config) {
 		c.shouldUpdate = f
@@ -30,19 +31,26 @@ func ShouldUpdate(f func() bool) Configurator {
 // SnapshotSubdirectory can be used to customize the location that snapshots are stored in.
 // e.g.
 //  cupaloy.New(SnapshotSubdirectory("testdata"))
-// Will create an instance where snapshots are stored in testdata/ rather than the default .snapshots/
+// Will create an instance where snapshots are stored in the "testdata" folder
+// Default: .snapshots
 func SnapshotSubdirectory(name string) Configurator {
 	return func(c *Config) {
 		c.subDirName = name
 	}
 }
 
+// FailOnUpdate controls whether tests should be failed when snapshots are updated.
+// By default this is true to prevent snapshots being accidentally updated in CI.
+// Default: true
 func FailOnUpdate(failOnUpdate bool) Configurator {
 	return func(c *Config) {
 		c.failOnUpdate = failOnUpdate
 	}
 }
 
+// CreateNewAutomatically controls whether snapshots should be automatically created
+// if no matching snapshot already exists.
+// Default: true
 func CreateNewAutomatically(createNewAutomatically bool) Configurator {
 	return func(c *Config) {
 		c.createNewAutomatically = createNewAutomatically
@@ -57,6 +65,8 @@ type Config struct {
 	createNewAutomatically bool
 }
 
+// NewDefaultConfig returns a new Config instance initialised with the same options as
+// the original Global instance (i.e. before any config changes were made to it)
 func NewDefaultConfig() *Config {
 	return (&Config{}).WithOptions(
 		SnapshotSubdirectory(".snapshots"),
@@ -66,6 +76,7 @@ func NewDefaultConfig() *Config {
 	)
 }
 
+// Global is the Config instance used by `cupaloy.SnapshotT` and other package-level functions.
 var Global = NewDefaultConfig()
 
 func (c *Config) clone() *Config {

--- a/examples/.snapshots/TestGlobalFailOnUpdate
+++ b/examples/.snapshots/TestGlobalFailOnUpdate
@@ -1,0 +1,1 @@
+This should fail because updating, but won't because of global setting

--- a/examples/.snapshots/examples_test-TestFailOnUpdate
+++ b/examples/.snapshots/examples_test-TestFailOnUpdate
@@ -1,0 +1,1 @@
+Hello world

--- a/examples/advanced_test.go
+++ b/examples/advanced_test.go
@@ -143,3 +143,33 @@ func TestFailedTestNoop(t *testing.T) {
 	cupaloy.SnapshotT(mockT, "This should not create a snapshot")
 	mockT.AssertNotCalled(t, "Error")
 }
+
+func TestGlobalFailOnUpdate(t *testing.T) {
+	cupaloy.Global = cupaloy.Global.WithOptions(
+		cupaloy.FailOnUpdate(false),
+		cupaloy.ShouldUpdate(func()bool{return true}))
+	// reset global after test
+	defer func(){cupaloy.Global = cupaloy.NewDefaultConfig()}()
+
+	mockT := &TestingT{}
+	mockT.On("Helper").Return()
+	mockT.On("Failed").Return(false)
+	mockT.On("Name").Return(t.Name())
+
+	cupaloy.SnapshotT(mockT, "This should fail because updating, but won't because of global setting")
+	mockT.AssertNotCalled(t, "Error")
+}
+
+func TestGlobalCreateNewAutomatically(t *testing.T) {
+	cupaloy.Global = cupaloy.Global.WithOptions(cupaloy.CreateNewAutomatically(false))
+	// reset global after test
+	defer func(){cupaloy.Global = cupaloy.NewDefaultConfig()}()
+
+	mockT := &TestingT{}
+	mockT.On("Helper").Return()
+	mockT.On("Failed").Return(false)
+	mockT.On("Name").Return(t.Name())
+
+	cupaloy.SnapshotT(mockT, "This should fail because doesn't exist")
+	mockT.AssertNotCalled(t, "Error")
+}

--- a/examples/advanced_test.go
+++ b/examples/advanced_test.go
@@ -173,3 +173,15 @@ func TestGlobalCreateNewAutomatically(t *testing.T) {
 	cupaloy.SnapshotT(mockT, "This should fail because doesn't exist")
 	mockT.AssertNotCalled(t, "Error")
 }
+
+func TestFailOnUpdate(t *testing.T) {
+	snapshotter := cupaloy.New(cupaloy.EnvVariableName("GOPATH"), cupaloy.FailOnUpdate(false))
+
+
+	err := snapshotter.Snapshot("Hello new world")
+	if err != nil {
+		t.Fatal("FailOnUpdate(false) should disable errors when updating snapshots")
+	}
+
+	snapshotter.Snapshot("Hello world") // reset snapshot to known state (ignoring return value)
+}

--- a/util.go
+++ b/util.go
@@ -104,13 +104,13 @@ func (c *Config) updateSnapshot(snapshotName string, snapshot string) error {
 		return err
 	}
 
-	if isNewSnapshot {
-		return fmt.Errorf("snapshot created for test %s", snapshotName)
-	}
-
 	if !c.failOnUpdate {
 		//TODO: should a warning still be printed here?
 		return nil
+	}
+	
+	if isNewSnapshot {
+		return fmt.Errorf("snapshot created for test %s", snapshotName)
 	}
 
 	return fmt.Errorf("snapshot updated for test %s", snapshotName)

--- a/util.go
+++ b/util.go
@@ -108,6 +108,11 @@ func (c *Config) updateSnapshot(snapshotName string, snapshot string) error {
 		return fmt.Errorf("snapshot created for test %s", snapshotName)
 	}
 
+	if !c.failOnUpdate {
+		//TODO: should a warning still be printed here?
+		return nil
+	}
+
 	return fmt.Errorf("snapshot updated for test %s", snapshotName)
 }
 


### PR DESCRIPTION
This is a prototype of Global configuration allowing users to modify behaviour of `cupaloy` for all calls as described in #4.
The intended usage is: in order to change the behaviour of `cupaloy` for all tests in a package the following (or similar) should be included in a test file for the package:
```go
func init() {
	cupaloy.Global = cupaloy.Global.WithOptions(
		cupaloy.FailOnUpdate(false),
		cupaloy.CreateNewAutomatically(false))
}
```

These options will then apply to all package level snapshot functions (Config snapshot functions will of course remain independent from the global config.

Fixes #4, Fixes #40