### PR TITLE
Update cupaloy.go

### DIFF
--- a/cupaloy.go
+++ b/cupaloy.go
@@ -80,8 +80,7 @@ func (c *Config) snapshot(snapshotName string, i ...interface{}) error {
 		if c.createNewAutomatically {
 			return c.updateSnapshot(snapshotName, snapshot)
 		}
-		//TODO: should an error still be printed here?
-		return nil
+		return fmt.Errorf("snapshot does not exist for test %s", snapshotName)
 	}
 	if err != nil {
 		return err

--- a/examples/advanced_test.go
+++ b/examples/advanced_test.go
@@ -169,9 +169,10 @@ func TestGlobalCreateNewAutomatically(t *testing.T) {
 	mockT.On("Helper").Return()
 	mockT.On("Failed").Return(false)
 	mockT.On("Name").Return(t.Name())
+	mockT.On("Error", mock.Anything).Return()
 
 	cupaloy.SnapshotT(mockT, "This should fail because doesn't exist")
-	mockT.AssertNotCalled(t, "Error")
+	mockT.AssertCalled(t, "Error")
 }
 
 func TestFailOnUpdate(t *testing.T) {

--- a/examples/advanced_test.go
+++ b/examples/advanced_test.go
@@ -172,7 +172,7 @@ func TestGlobalCreateNewAutomatically(t *testing.T) {
 	mockT.On("Error", mock.Anything).Return()
 
 	cupaloy.SnapshotT(mockT, "This should fail because doesn't exist")
-	mockT.AssertCalled(t, "Error")
+	mockT.AssertCalled(t, "Error", mock.Anything)
 }
 
 func TestFailOnUpdate(t *testing.T) {


### PR DESCRIPTION
```
cupaloy.Global = cupaloy.Global.WithOptions(
		cupaloy.CreateNewAutomatically(false),
		cupaloy.EnvVariableName(updateSnapshotsEnv),
		cupaloy.FailOnUpdate(false),
		cupaloy.ShouldUpdate(func() bool { return updateSnapshot}),
		cupaloy.SnapshotSubdirectory(updateSnapshotsDir),
	)
```

Sorry missed this earlier. This is the set of config I'm using. When snapshots don't exist and I'm running in bazel setting it is not failing as expected.