### PR TITLE
Use error structs instead of fmt.Errorf

### DIFF
--- a/cupaloy.go
+++ b/cupaloy.go
@@ -105,7 +105,7 @@ func (c *Config) snapshot(snapshotName string, i ...interface{}) error {
 		if c.createNewAutomatically {
 			return c.updateSnapshot(snapshotName, prevSnapshot, snapshot)
 		}
-		return internal.ErrNoSnapshot{snapshotName}
+		return internal.ErrNoSnapshot{Name: snapshotName}
 	}
 	if err != nil {
 		return err

--- a/examples/advanced_test.go
+++ b/examples/advanced_test.go
@@ -2,6 +2,7 @@ package examples_test
 
 import (
 	"bytes"
+	"github.com/bradleyjkemp/cupaloy/v2/internal"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -49,6 +50,7 @@ func TestConfig(t *testing.T) {
 // This is to prevent you accidentally updating your snapshots in CI
 func TestUpdate(t *testing.T) {
 	snapshotter := cupaloy.New(cupaloy.EnvVariableName("HOME"))
+	defer snapshotter.Snapshot("Hello world") // reset snapshot to known state
 
 	err := snapshotter.Snapshot("Hello world")
 	if err != nil {
@@ -59,11 +61,11 @@ func TestUpdate(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Updating a snapshot with a new value is always an error %s", err)
 	}
-	if err.Error() != "snapshot updated for test examples_test-TestUpdate" {
-		t.Fatalf("Error returned will say that snapshot was updated")
+	if _, ok := err.(internal.ErrSnapshotUpdated); !ok {
+		t.Fatalf("Error returned will be of type ErrSnapshotUpdated")
 	}
 
-	snapshotter.Snapshot("Hello world") // reset snapshot to known state
+
 }
 
 // If a snapshot doesn't exist then it is created and an error returned
@@ -81,8 +83,8 @@ func TestMissingSnapshot(t *testing.T) {
 	if err == nil {
 		t.Fatalf("This will always return an error %s", err)
 	}
-	if err.Error() != "snapshot created for test examples_test-TestMissingSnapshot" {
-		t.Fatalf("Error returned will say that snapshot was created %s", err)
+	if _, ok := err.(internal.ErrSnapshotCreated); !ok {
+		t.Fatalf("Error returned will be of type ErrSnapshotCreated")
 	}
 }
 

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,0 +1,37 @@
+package internal
+
+import "fmt"
+
+type ErrSnapshotCreated struct {
+	Name     string
+	Contents string
+}
+
+func (e ErrSnapshotCreated) Error() string {
+	return fmt.Sprintf("snapshot created for test %s, with contents:\n%s", e.Name, e.Contents)
+}
+
+type ErrSnapshotUpdated struct {
+	Name string
+	Diff string
+}
+
+func (e ErrSnapshotUpdated) Error() string {
+	return fmt.Sprintf("snapshot %s updated:\n%s", e.Name, e.Diff)
+}
+
+type ErrSnapshotMismatch struct {
+	Diff string
+}
+
+func (e ErrSnapshotMismatch) Error() string {
+	return fmt.Sprintf("snapshot not equal:\n%s", e.Diff)
+}
+
+type ErrNoSnapshot struct {
+	Name string
+}
+
+func (e ErrNoSnapshot) Error() string {
+	return fmt.Sprintf("snapshot %s does not exist", e.Name)
+}


### PR DESCRIPTION
Fixes #42 (ErrSnapshotUpdated and ErrSnapshotCreated both include a diff)
Fixes #24 (Tests can identify type of error returned)