### PR TITLE
Add option to specify custom snapshot differ

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,6 +76,15 @@ func SnapshotFileExtension(snapshotFileExtension string) Configurator {
 	}
 }
 
+// DiffSnapshots allows you to change the differ used for comparing the
+// previous snapshot to the current.
+// Default: Internal differ using difflib
+func DiffSnapshots(differ func(previous, current string) string) Configurator {
+	return func(c *Config) {
+		c.diffSnapshots = differ
+	}
+}
+
 // Config provides the same snapshotting functions with additional configuration capabilities.
 type Config struct {
 	shouldUpdate           func() bool
@@ -84,6 +93,7 @@ type Config struct {
 	createNewAutomatically bool
 	fatalOnMismatch        bool
 	snapshotFileExtension  string
+	diffSnapshots          func(previous, current string) string
 }
 
 // NewDefaultConfig returns a new Config instance initialised with the same options as
@@ -96,6 +106,7 @@ func NewDefaultConfig() *Config {
 		CreateNewAutomatically(true),
 		FatalOnMismatch(false),
 		SnapshotFileExtension(""),
+		DiffSnapshots(diffSnapshots),
 	)
 }
 
@@ -110,5 +121,6 @@ func (c *Config) clone() *Config {
 		createNewAutomatically: c.createNewAutomatically,
 		fatalOnMismatch:        c.fatalOnMismatch,
 		snapshotFileExtension:  c.snapshotFileExtension,
+		diffSnapshots:          c.diffSnapshots,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -76,8 +76,8 @@ func SnapshotFileExtension(snapshotFileExtension string) Configurator {
 	}
 }
 
-// DiffSnapshots allows you to change the differ used for comparing the
-// previous snapshot to the current.
+// DiffSnapshots allows you to change the diffing function used to display the
+// difference between the previous snapshot and the current.
 // Default: Internal differ using difflib
 func DiffSnapshots(differ func(previous, current string) string) Configurator {
 	return func(c *Config) {

--- a/cupaloy.go
+++ b/cupaloy.go
@@ -122,6 +122,6 @@ func (c *Config) snapshot(snapshotName string, i ...interface{}) error {
 	}
 
 	return internal.ErrSnapshotMismatch{
-		Diff: diffSnapshots(prevSnapshot, snapshot),
+		Diff: c.diffSnapshots(prevSnapshot, snapshot),
 	}
 }

--- a/util.go
+++ b/util.go
@@ -111,7 +111,7 @@ func (c *Config) updateSnapshot(snapshotName string, prevSnapshot string, snapsh
 		return nil
 	}
 
-	snapshotDiff := diffSnapshots(prevSnapshot, snapshot)
+	snapshotDiff := c.diffSnapshots(prevSnapshot, snapshot)
 
 	if isNewSnapshot {
 		return internal.ErrSnapshotCreated{


### PR DESCRIPTION
I have a go struct with a large string member and when diffed it looks pretty ugly and hard to read as the new lines are not interpreted and it thinks the file is a single line.

So I added the ability to add a custom differ as I prefer to use `go-cmp`.