### PR TITLE
Add an option to disable usage of stringer methods.

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,6 +76,15 @@ func SnapshotFileExtension(snapshotFileExtension string) Configurator {
 	}
 }
 
+// UseStringerMethods invoke String() or Error() methods when available rather than dumping the object.
+// This should probably be disabled by default but is not for backwards compatibility reasons.
+// Default: true
+func UseStringerMethods(useStringerMethods bool) Configurator {
+	return func(c *Config) {
+		c.useStringerMethods = useStringerMethods
+	}
+}
+
 // Config provides the same snapshotting functions with additional configuration capabilities.
 type Config struct {
 	shouldUpdate           func() bool
@@ -84,6 +93,7 @@ type Config struct {
 	createNewAutomatically bool
 	fatalOnMismatch        bool
 	snapshotFileExtension  string
+	useStringerMethods     bool
 }
 
 // NewDefaultConfig returns a new Config instance initialised with the same options as
@@ -96,6 +106,7 @@ func NewDefaultConfig() *Config {
 		CreateNewAutomatically(true),
 		FatalOnMismatch(false),
 		SnapshotFileExtension(""),
+		UseStringerMethods(true),
 	)
 }
 
@@ -110,5 +121,6 @@ func (c *Config) clone() *Config {
 		createNewAutomatically: c.createNewAutomatically,
 		fatalOnMismatch:        c.fatalOnMismatch,
 		snapshotFileExtension:  c.snapshotFileExtension,
+		useStringerMethods:     c.useStringerMethods,
 	}
 }

--- a/cupaloy.go
+++ b/cupaloy.go
@@ -98,7 +98,7 @@ func (c *Config) WithOptions(configurators ...Configurator) *Config {
 }
 
 func (c *Config) snapshot(snapshotName string, i ...interface{}) error {
-	snapshot := takeSnapshot(i...)
+	snapshot := c.takeSnapshot(i...)
 
 	prevSnapshot, err := c.readSnapshot(snapshotName)
 	if os.IsNotExist(err) {
@@ -111,7 +111,7 @@ func (c *Config) snapshot(snapshotName string, i ...interface{}) error {
 		return err
 	}
 
-	if snapshot == prevSnapshot || takeV1Snapshot(i...) == prevSnapshot {
+	if snapshot == prevSnapshot || c.takeV1Snapshot(i...) == prevSnapshot {
 		// previous snapshot matches current value
 		return nil
 	}

--- a/examples/.snapshots/TestUseStringerMethods-disabled
+++ b/examples/.snapshots/TestUseStringerMethods-disabled
@@ -1,0 +1,2 @@
+(examples_test.stringer) {
+}

--- a/examples/.snapshots/TestUseStringerMethods-enabled
+++ b/examples/.snapshots/TestUseStringerMethods-enabled
@@ -1,0 +1,1 @@
+(examples_test.stringer) with stringer

--- a/examples/advanced_test.go
+++ b/examples/advanced_test.go
@@ -2,10 +2,11 @@ package examples_test
 
 import (
 	"bytes"
-	"github.com/bradleyjkemp/cupaloy/v2/internal"
 	"io/ioutil"
 	"strings"
 	"testing"
+
+	"github.com/bradleyjkemp/cupaloy/v2/internal"
 
 	"github.com/bradleyjkemp/cupaloy/v2"
 	"github.com/stretchr/testify/mock"
@@ -64,7 +65,6 @@ func TestUpdate(t *testing.T) {
 	if _, ok := err.(internal.ErrSnapshotUpdated); !ok {
 		t.Fatalf("Error returned will be of type ErrSnapshotUpdated")
 	}
-
 
 }
 
@@ -208,4 +208,23 @@ func TestGlobalFatalOnMismatch(t *testing.T) {
 func TestSnapshotFileExtension(t *testing.T) {
 	snapshotter := cupaloy.New(cupaloy.SnapshotFileExtension(".myextension"))
 	snapshotter.SnapshotT(t, "This should end up in a file with extension .myextension")
+}
+
+type stringer struct {
+}
+
+func (s stringer) String() string {
+	return "with stringer"
+}
+
+func TestUseStringerMethods(t *testing.T) {
+	s := stringer{}
+
+	t.Run("enabled", func(t *testing.T) {
+		cupaloy.New(cupaloy.UseStringerMethods(true)).SnapshotT(t, s)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		cupaloy.New(cupaloy.UseStringerMethods(false)).SnapshotT(t, s)
+	})
 }


### PR DESCRIPTION
This is especially annoying for snapshotting custom errors that contain
some payload. The payload would arbitrary be dismissed which is
confusing.

fixes #45